### PR TITLE
[LB-337] 카프카, 레디스 pub/sub 기반 알림

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 kotlin {

--- a/build.gradle
+++ b/build.gradle
@@ -1,56 +1,60 @@
 plugins {
-	id 'org.jetbrains.kotlin.jvm' version '1.9.25'
-	id 'org.jetbrains.kotlin.plugin.spring' version '1.9.25'
-	id 'org.springframework.boot' version '3.5.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.25'
+    id 'org.springframework.boot' version '3.5.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.lgcms'
-version = '0.0.1-SNAPSHOT'
+version = '0.1'
 description = 'Notification project for lgcms'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
-	implementation 'io.projectreactor.kotlin:reactor-kotlin-extensions'
-	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
-	implementation 'org.springframework.kafka:spring-kafka'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	runtimeOnly 'org.postgresql:r2dbc-postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-	testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
+    implementation 'io.projectreactor.kotlin:reactor-kotlin-extensions'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll '-Xjsr305=strict'
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll '-Xjsr305=strict'
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/com/lgcms/notification/NotificationApplication.kt
+++ b/src/main/kotlin/com/lgcms/notification/NotificationApplication.kt
@@ -7,5 +7,5 @@ import org.springframework.boot.runApplication
 class NotificationApplication
 
 fun main(args: Array<String>) {
-	runApplication<NotificationApplication>(*args)
+    runApplication<NotificationApplication>(*args)
 }

--- a/src/main/kotlin/com/lgcms/notification/advice/NotificationControllerAdvice.kt
+++ b/src/main/kotlin/com/lgcms/notification/advice/NotificationControllerAdvice.kt
@@ -1,0 +1,43 @@
+package com.lgcms.notification.advice
+
+import com.lgcms.notification.common.dto.BaseResponse
+import com.lgcms.notification.common.dto.exception.BaseException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class NotificationControllerAdvice {
+    val log = LoggerFactory.getLogger(NotificationControllerAdvice::class.java)
+
+    @ExceptionHandler(BaseException::class)
+    fun handleException(e: BaseException): ResponseEntity<BaseResponse<String?>> {
+        val errorCode = e.getErrorCode()
+        return ResponseEntity
+            .status(errorCode.httpStatus.value())
+            .body(BaseResponse.onFailure(errorCode.status, errorCode.message, null))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleException(e: MethodArgumentNotValidException): ResponseEntity<BaseResponse<String?>> {
+        val errorMessage = e.bindingResult
+            .fieldErrors
+            .firstOrNull()
+            ?.defaultMessage
+            ?: "잘못된 요청입니다."
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST.value())
+            .body(BaseResponse.onFailure("ARGUMENT_ERROR", errorMessage, null))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<BaseResponse<String?>> {
+        log.error("에러 발생 : ", e)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(BaseResponse.onFailure("INTERNAL_SERVER_ERRROR", "내부 서버 에러", null))
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/api/dto/NotificationListResponse.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/dto/NotificationListResponse.kt
@@ -1,0 +1,7 @@
+package com.lgcms.notification.api.dto
+
+import com.lgcms.notification.domain.NotificationEntity
+
+data class NotificationListResponse(
+    val notifications: List<NotificationEntity>
+)

--- a/src/main/kotlin/com/lgcms/notification/api/dto/NotificationReadRequest.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/dto/NotificationReadRequest.kt
@@ -1,0 +1,7 @@
+package com.lgcms.notification.api.dto
+
+import java.util.*
+
+data class NotificationReadRequest(
+    val notificationId: UUID,
+)

--- a/src/main/kotlin/com/lgcms/notification/api/dto/SimpleStringResponse.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/dto/SimpleStringResponse.kt
@@ -1,0 +1,5 @@
+package com.lgcms.notification.api.dto
+
+data class SimpleStringResponse(
+    val message: String
+)

--- a/src/main/kotlin/com/lgcms/notification/api/internal/NotificationInternalController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/internal/NotificationInternalController.kt
@@ -1,0 +1,18 @@
+package com.lgcms.notification.api.internal
+
+import com.lgcms.notification.service.NotificationService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/student/notification")
+class NotificationInternalController(
+    private val notificationService: NotificationService,
+) {
+    @GetMapping("/status")
+    fun getServerStatus(): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.ok(notificationService.getServerStatus())
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/api/open/NotificationAdminController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/open/NotificationAdminController.kt
@@ -1,0 +1,24 @@
+package com.lgcms.notification.api.open
+
+import com.lgcms.notification.api.dto.SimpleStringResponse
+import com.lgcms.notification.common.dto.BaseResponse
+import com.lgcms.notification.common.kafka.dto.KafkaEvent
+import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
+import com.lgcms.notification.service.NotificationService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/admin/notification")
+class NotificationAdminController(
+    private val notificationService: NotificationService,
+) {
+    @PostMapping
+    suspend fun sendNotification(
+        @RequestBody request: KafkaEvent<NotificationEventRequest.QnaCreated>,
+    ): ResponseEntity<BaseResponse<SimpleStringResponse>> {
+        notificationService.sendNotification(request)
+        return ResponseEntity.ok()
+            .body(BaseResponse.ok(SimpleStringResponse("알림이 전송되었습니다.")))
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/api/open/NotificationAdminController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/open/NotificationAdminController.kt
@@ -21,4 +21,9 @@ class NotificationAdminController(
         return ResponseEntity.ok()
             .body(BaseResponse.ok(SimpleStringResponse("알림이 전송되었습니다.")))
     }
+
+    @GetMapping("/status")
+    fun getServerStatus(): ResponseEntity<Map<String, Any>> {
+        return ResponseEntity.ok(notificationService.getServerStatus())
+    }
 }

--- a/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.util.UUID
 
 @RestController
 @RequestMapping("/student/notification")
@@ -37,9 +38,9 @@ class NotificationStudentController(
     @DeleteMapping("/read")
     suspend fun readNotification(
         @RequestHeader("X-USER-ID") memberId: Long,
-        @RequestBody request: NotificationReadRequest,
+        @RequestParam notificationId: UUID,
     ): ResponseEntity<BaseResponse<SimpleStringResponse>> {
-        notificationService.readNotification(memberId, request)
+        notificationService.readNotification(memberId, notificationId)
         return ResponseEntity.ok(BaseResponse.ok(SimpleStringResponse("읽음 완료")))
     }
 }

--- a/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
@@ -1,0 +1,26 @@
+package com.lgcms.notification.api.open
+
+import com.lgcms.notification.domain.NotificationEntity
+import com.lgcms.notification.service.NotificationService
+import kotlinx.coroutines.flow.Flow
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/student/notification")
+class NotificationStudentController(
+    private val notificationService: NotificationService,
+) {
+    @GetMapping(
+        value = ["/subscribe"],
+        produces = [MediaType.TEXT_EVENT_STREAM_VALUE]
+    )
+    suspend fun getUserNotificationStream(
+        @RequestHeader("X-USER-ID") memberId: Long,
+    ): Flow<NotificationEntity> {
+        return notificationService.subscribe(memberId)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
@@ -1,9 +1,12 @@
 package com.lgcms.notification.api.open
 
+import com.lgcms.notification.api.dto.NotificationListResponse
+import com.lgcms.notification.common.dto.BaseResponse
 import com.lgcms.notification.domain.NotificationEntity
 import com.lgcms.notification.service.NotificationService
 import kotlinx.coroutines.flow.Flow
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,5 +25,13 @@ class NotificationStudentController(
         @RequestHeader("X-USER-ID") memberId: Long,
     ): Flow<NotificationEntity> {
         return notificationService.subscribe(memberId)
+    }
+
+    @GetMapping()
+    suspend fun getUserNotifications(
+        @RequestHeader("X-USER-ID") memberId: Long,
+    ): ResponseEntity<BaseResponse<NotificationListResponse>> {
+        return ResponseEntity.ok()
+            .body(BaseResponse.ok(NotificationListResponse(notificationService.findById(memberId))))
     }
 }

--- a/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
+++ b/src/main/kotlin/com/lgcms/notification/api/open/NotificationStudentController.kt
@@ -1,16 +1,15 @@
 package com.lgcms.notification.api.open
 
 import com.lgcms.notification.api.dto.NotificationListResponse
+import com.lgcms.notification.api.dto.NotificationReadRequest
+import com.lgcms.notification.api.dto.SimpleStringResponse
 import com.lgcms.notification.common.dto.BaseResponse
 import com.lgcms.notification.domain.NotificationEntity
 import com.lgcms.notification.service.NotificationService
 import kotlinx.coroutines.flow.Flow
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/student/notification")
@@ -33,5 +32,14 @@ class NotificationStudentController(
     ): ResponseEntity<BaseResponse<NotificationListResponse>> {
         return ResponseEntity.ok()
             .body(BaseResponse.ok(NotificationListResponse(notificationService.findById(memberId))))
+    }
+
+    @DeleteMapping("/read")
+    suspend fun readNotification(
+        @RequestHeader("X-USER-ID") memberId: Long,
+        @RequestBody request: NotificationReadRequest,
+    ): ResponseEntity<BaseResponse<SimpleStringResponse>> {
+        notificationService.readNotification(memberId, request)
+        return ResponseEntity.ok(BaseResponse.ok(SimpleStringResponse("읽음 완료")))
     }
 }

--- a/src/main/kotlin/com/lgcms/notification/common/dto/BaseResponse.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/dto/BaseResponse.kt
@@ -1,0 +1,17 @@
+package com.lgcms.notification.common.dto
+
+data class BaseResponse<T>(
+    val status: String,
+    val message: String,
+    val data: T?
+) {
+    companion object {
+        fun <T> ok(result: T): BaseResponse<T> {
+            return BaseResponse("OK", "호출에 성공했습니다", result)
+        }
+
+        fun <T> onFailure(status: String, message: String, data: T?): BaseResponse<T?> {
+            return BaseResponse(status, message, data)
+        }
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/dto/exception/BaseException.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/dto/exception/BaseException.kt
@@ -1,0 +1,9 @@
+package com.lgcms.notification.common.dto.exception
+
+class BaseException(
+    val errorCodeInterface: ErrorCodeInterface
+) : RuntimeException() {
+    fun getErrorCode(): ErrorCode {
+        return errorCodeInterface.getErrorCode()
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/dto/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/dto/exception/ErrorCode.kt
@@ -1,0 +1,9 @@
+package com.lgcms.notification.common.dto.exception
+
+import org.springframework.http.HttpStatus
+
+data class ErrorCode(
+    val status: String,
+    val message: String,
+    val httpStatus: HttpStatus,
+)

--- a/src/main/kotlin/com/lgcms/notification/common/dto/exception/ErrorCodeInterface.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/dto/exception/ErrorCodeInterface.kt
@@ -1,0 +1,5 @@
+package com.lgcms.notification.common.dto.exception
+
+interface ErrorCodeInterface {
+    fun getErrorCode(): ErrorCode
+}

--- a/src/main/kotlin/com/lgcms/notification/common/dto/exception/NotificationError.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/dto/exception/NotificationError.kt
@@ -1,0 +1,20 @@
+package com.lgcms.notification.common.dto.exception
+
+import org.springframework.http.HttpStatus
+
+enum class NotificationError(
+    val status: String,
+    val message: String,
+    val httpStatus: HttpStatus
+) : ErrorCodeInterface {
+    NO_SUCH_NOTIFICATION_TYPE("NOTI_001", "존재하지 않는 알림 타입입니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    override fun getErrorCode(): ErrorCode {
+        return ErrorCode(
+            status = status,
+            message = message,
+            httpStatus = httpStatus
+        )
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/config/KafkaConfig.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/config/KafkaConfig.kt
@@ -1,0 +1,68 @@
+package com.lgcms.notification.common.kafka.config
+
+import com.lgcms.notification.common.kafka.util.serializer.JsonKafkaDeserializer
+import com.lgcms.notification.common.kafka.util.serializer.JsonKafkaSerializer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.*
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+import org.springframework.kafka.support.serializer.JsonDeserializer
+
+@Configuration
+@EnableKafka
+class KafkaConfig(
+    @Value("\${spring.kafka.bootstrap-servers}")
+    private val bootstrapServers: String,
+    @Value("\${spring.kafka.consumer.group-id}")
+    private val groupId: String,
+) {
+
+    @Bean
+    fun producerFactory(): ProducerFactory<String, Any> {
+        val config: MutableMap<String?, Any?> = HashMap<String?, Any?>()
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonKafkaSerializer::class.java)
+        return DefaultKafkaProducerFactory(config)
+    }
+
+    @Bean
+    fun kafkaTemplate(): KafkaTemplate<String, Any> {
+        return KafkaTemplate(producerFactory())
+    }
+
+    private fun commonConsumerProps(): MutableMap<String?, Any?> {
+        val props: MutableMap<String?, Any?> = HashMap<String?, Any?>()
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer::class.java)
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer::class.java)
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer::class.java)
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer::class.java)
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*")
+        return props
+    }
+
+    fun <T> consumerFactory(valueType: Class<T>): ConsumerFactory<String, T> {
+        val props = commonConsumerProps().toMutableMap()
+        return DefaultKafkaConsumerFactory(
+            props,
+            StringDeserializer(),
+            JsonKafkaDeserializer(valueType)
+        )
+    }
+
+    fun <T> kafkaListenerContainerFactory(valueType: Class<T>): ConcurrentKafkaListenerContainerFactory<String, T> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, T>()
+        factory.consumerFactory = consumerFactory(valueType)
+        return factory
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/config/KafkaListenerConfig.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/config/KafkaListenerConfig.kt
@@ -1,0 +1,13 @@
+package com.lgcms.notification.common.kafka.config
+
+import com.lgcms.notification.common.kafka.dto.KafkaEvent
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+
+@Configuration
+class KafkaListenerConfig(private val kafkaConfig: KafkaConfig) {
+    @Bean
+    fun defaultFactory(): ConcurrentKafkaListenerContainerFactory<String, KafkaEvent<*>> =
+        kafkaConfig.kafkaListenerContainerFactory(KafkaEvent::class.java)
+}

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/dto/KafkaEvent.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/dto/KafkaEvent.kt
@@ -1,0 +1,8 @@
+package com.lgcms.notification.common.kafka.dto
+
+data class KafkaEvent<T>(
+    val eventId: String,
+    val eventType: String,
+    val eventTime: String,
+    val data: T,
+)

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/util/KafkaEventFactory.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/util/KafkaEventFactory.kt
@@ -1,0 +1,14 @@
+package com.lgcms.notification.common.kafka.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.lgcms.notification.common.kafka.dto.KafkaEvent
+import org.springframework.stereotype.Component
+
+@Component
+class KafkaEventFactory(
+    private val objectMapper: ObjectMapper
+) {
+    fun <T> convert(event: KafkaEvent<*>, clazz: Class<T>): T {
+        return objectMapper.convertValue(event.data, clazz)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/util/KafkaObjectMapper.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/util/KafkaObjectMapper.kt
@@ -1,0 +1,16 @@
+package com.lgcms.notification.common.kafka.util
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+object KafkaObjectMapper {
+    fun create(): ObjectMapper {
+        return jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/util/serializer/JsonKafkaDeserializer.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/util/serializer/JsonKafkaDeserializer.kt
@@ -1,0 +1,16 @@
+package com.lgcms.notification.common.kafka.util.serializer
+
+import com.lgcms.notification.common.kafka.util.KafkaObjectMapper.create
+import org.apache.kafka.common.serialization.Deserializer
+
+class JsonKafkaDeserializer<T>(private val targetType: Class<T>) : Deserializer<T> {
+    private val objectMapper = create()
+
+    override fun deserialize(topic: String?, data: ByteArray?): T? {
+        return try {
+            data?.let { objectMapper.readValue(it, targetType) }
+        } catch (e: Exception) {
+            throw RuntimeException("Kafka JSON Deserialize error", e)
+        }
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/common/kafka/util/serializer/JsonKafkaSerializer.kt
+++ b/src/main/kotlin/com/lgcms/notification/common/kafka/util/serializer/JsonKafkaSerializer.kt
@@ -1,0 +1,16 @@
+package com.lgcms.notification.common.kafka.util.serializer
+
+import com.lgcms.notification.common.kafka.util.KafkaObjectMapper.create
+import org.apache.kafka.common.serialization.Serializer
+
+class JsonKafkaSerializer<T> : Serializer<T?> {
+    private val objectMapper = create()
+
+    override fun serialize(topic: String?, data: T?): ByteArray? {
+        try {
+            return objectMapper.writeValueAsBytes(data)
+        } catch (e: Exception) {
+            throw RuntimeException("Kafka JSON Serialize error", e)
+        }
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/config/ObjectMapperConfig.kt
+++ b/src/main/kotlin/com/lgcms/notification/config/ObjectMapperConfig.kt
@@ -1,0 +1,22 @@
+package com.lgcms.notification.config
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+@Configuration
+class ObjectMapperConfig {
+    @Bean
+    @Primary
+    fun objectMapper(): ObjectMapper {
+        return jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/lgcms/notification/config/R2dbcConfig.kt
@@ -1,0 +1,27 @@
+package com.lgcms.notification.config
+
+import io.r2dbc.spi.ConnectionFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.core.io.ClassPathResource
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
+import org.springframework.r2dbc.connection.init.ConnectionFactoryInitializer
+import org.springframework.r2dbc.connection.init.ResourceDatabasePopulator
+
+@Configuration
+@EnableR2dbcRepositories
+class R2dbcConfig {
+    @Bean
+    @Profile("!dev")
+    fun connectionFactoryInitializer(connectionFactory: ConnectionFactory): ConnectionFactoryInitializer {
+        val initializer = ConnectionFactoryInitializer()
+        initializer.setConnectionFactory(connectionFactory)
+
+        val populator = ResourceDatabasePopulator()
+        populator.addScript(ClassPathResource("sql/schema.sql"))
+
+        initializer.setDatabasePopulator(populator)
+        return initializer
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/config/RedisConfig.kt
+++ b/src/main/kotlin/com/lgcms/notification/config/RedisConfig.kt
@@ -1,0 +1,46 @@
+package com.lgcms.notification.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig(
+    @Value("\${spring.data.redis.host}") private val redisHost: String,
+    @Value("\${spring.data.redis.port}") private val redisPort: Int,
+    @Value("\${spring.data.redis.database}") private val redisDatabase: Int,
+    private val objectMapper: ObjectMapper
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        val connectionFactory = LettuceConnectionFactory(redisHost, redisPort)
+        connectionFactory.database = redisDatabase
+        return connectionFactory
+    }
+
+    @Bean
+    fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
+        val template = RedisTemplate<String, String>()
+        template.connectionFactory = connectionFactory
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
+        return template
+    }
+
+    @Bean
+    fun redisMessageListenerContainer(
+        connectionFactory: RedisConnectionFactory
+    ): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(connectionFactory)
+        return container
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/domain/NotificationEntity.kt
+++ b/src/main/kotlin/com/lgcms/notification/domain/NotificationEntity.kt
@@ -1,0 +1,24 @@
+package com.lgcms.notification.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+import java.util.*
+
+@Table(name = "notifications")
+data class NotificationEntity(
+    @Id
+    @Column("id")
+    val id: UUID? = null,
+    @Column("notification_type")
+    val notificationType: NotificationType,
+    @Column("member_id")
+    val memberId: Long,
+    @Column("content")
+    val content: String,
+    @Column("web_path")
+    val webPath: String,
+    @Column("created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/lgcms/notification/domain/NotificationEntityFactory.kt
+++ b/src/main/kotlin/com/lgcms/notification/domain/NotificationEntityFactory.kt
@@ -1,0 +1,65 @@
+package com.lgcms.notification.domain
+
+import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationEntityFactory(
+    @Value("\${front-routes.student-main-page}")
+    private val studentMainPage: String,
+    @Value("\${front-routes.lecturer-main-page}")
+    private val lecturerMainPage: String,
+    @Value("\${front-routes.qna-page}")
+    private val qnaPage: String,
+    @Value("\${front-routes.lecture-edit-page}")
+    private val lectureEditPage: String,
+    @Value("\${front-routes.leveltest-report-page}")
+    private val leveltestReportPage: String,
+) {
+    fun create(request: NotificationEventRequest): NotificationEntity {
+        return when (request) {
+            is NotificationEventRequest.MemberJoined -> NotificationEntity(
+                memberId = request.memberId,
+                notificationType = NotificationType.MEMBER_JOINED,
+                content = "${request.nickname}님 회원가입을 축하합니다.",
+                webPath = studentMainPage,
+            )
+
+            is NotificationEventRequest.RoleModified -> NotificationEntity(
+                memberId = request.memberId,
+                notificationType = NotificationType.ROLE_MODIFIED,
+                content = "${request.nickname}님 ${request.memberRoleName}가 되었습니다",
+                webPath = lecturerMainPage,
+            )
+
+            is NotificationEventRequest.QnaCreated -> NotificationEntity(
+                memberId = request.memberId,
+                notificationType = NotificationType.QNA_CREATED,
+                content = "${request.lectureName}에서 질문이 등록되었습니다",
+                webPath = String.format(qnaPage, request.qnaId),
+            )
+
+            is NotificationEventRequest.QnaAnswered -> NotificationEntity(
+                memberId = request.memberId,
+                notificationType = NotificationType.QNA_ANSWERED,
+                content = "${request.questionTitle} 질문에 답변이 등록되었습니다",
+                webPath = String.format(qnaPage, request.qnaId),
+            )
+
+            is NotificationEventRequest.EncodingStatus -> NotificationEntity(
+                memberId = request.memberId,
+                notificationType = NotificationType.ENCODING_STATUS,
+                content = "${request.lectureName} 강의 영상 업로드를 ${request.status}헀습니다",
+                webPath = String.format(lectureEditPage, request.lectureId),
+            )
+
+            is NotificationEventRequest.LevelTestReportRequested -> NotificationEntity(
+                memberId = request.memberId,
+                notificationType = NotificationType.LEVELTEST_REPORT_REQUEST,
+                content = "레벨 테스트 레포트 페이지가 완성되었습니다",
+                webPath = String.format(leveltestReportPage, request.studentReportId),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/domain/NotificationType.kt
+++ b/src/main/kotlin/com/lgcms/notification/domain/NotificationType.kt
@@ -1,0 +1,10 @@
+package com.lgcms.notification.domain
+
+enum class NotificationType {
+    MEMBER_JOINED,
+    ROLE_MODIFIED,
+    QNA_CREATED,
+    QNA_ANSWERED,
+    ENCODING_STATUS,
+    LEVELTEST_REPORT_REQUEST,
+}

--- a/src/main/kotlin/com/lgcms/notification/event/kafka/consumer/NotificationConsumer.kt
+++ b/src/main/kotlin/com/lgcms/notification/event/kafka/consumer/NotificationConsumer.kt
@@ -1,0 +1,39 @@
+package com.lgcms.notification.event.kafka.consumer
+
+import com.lgcms.notification.common.kafka.dto.KafkaEvent
+import com.lgcms.notification.event.redis.publisher.NotificationPublisher
+import com.lgcms.notification.service.NotificationService
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationConsumer(
+    private val notificationService: NotificationService,
+    private val notificationPublisher: NotificationPublisher,
+) {
+    private val logger = LoggerFactory.getLogger(NotificationConsumer::class.java)
+
+    @KafkaListener(
+        topics = ["NOTIFICATION"],
+        containerFactory = "defaultFactory",
+    )
+    suspend fun handleNotificationEvent(
+        @Payload kafkaEvent: KafkaEvent<*>,
+    ) {
+        try {
+            val notificationEntity = notificationService.convertEventAndSave(kafkaEvent)
+
+            runBlocking {
+                notificationPublisher.publishNotification(notificationEntity)
+            }
+        } catch (e: Exception) {
+            logger.error(
+                "알림 처리 중 오류 발생: eventId={}, error={}",
+                kafkaEvent.eventId, e.message, e
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/event/kafka/dto/NotificationEventRequest.kt
+++ b/src/main/kotlin/com/lgcms/notification/event/kafka/dto/NotificationEventRequest.kt
@@ -1,0 +1,38 @@
+package com.lgcms.notification.event.kafka.dto
+
+sealed class NotificationEventRequest {
+    data class MemberJoined(
+        val memberId: Long,
+        val nickname: String,
+    ) : NotificationEventRequest()
+
+    data class RoleModified(
+        val memberId: Long,
+        val nickname: String,
+        val memberRoleName: String,
+    ) : NotificationEventRequest()
+
+    data class QnaCreated(
+        val memberId: Long,
+        val qnaId: Long,
+        val lectureName: String,
+    ) : NotificationEventRequest()
+
+    data class QnaAnswered(
+        val memberId: Long,
+        val qnaId: Long,
+        val questionTitle: String,
+    ) : NotificationEventRequest()
+
+    data class EncodingStatus(
+        val memberId: Long,
+        val lectureName: String,
+        val lectureId: Long,
+        val status: String,
+    ) : NotificationEventRequest()
+
+    data class LevelTestReportRequested(
+        val memberId: Long,
+        val studentReportId: Long,
+    ) : NotificationEventRequest()
+}

--- a/src/main/kotlin/com/lgcms/notification/event/kafka/producer/NotificationProducer.kt
+++ b/src/main/kotlin/com/lgcms/notification/event/kafka/producer/NotificationProducer.kt
@@ -1,0 +1,15 @@
+package com.lgcms.notification.event.kafka.producer
+
+import com.lgcms.notification.common.kafka.dto.KafkaEvent
+import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationProducer(
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+) {
+    suspend fun sendNotificationEvent(event: KafkaEvent<NotificationEventRequest.QnaCreated>) {
+        kafkaTemplate.send("NOTIFICATION", event.eventId, event)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/event/redis/publisher/NotificationPublisher.kt
+++ b/src/main/kotlin/com/lgcms/notification/event/redis/publisher/NotificationPublisher.kt
@@ -1,0 +1,20 @@
+package com.lgcms.notification.event.redis.publisher
+
+import com.lgcms.notification.domain.NotificationEntity
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationPublisher(
+    private val redisTemplate: RedisTemplate<String, String>
+) {
+    private val ChannelName = "notifications_internal"
+
+    fun publishNotification(notification: NotificationEntity) {
+        redisTemplate.convertAndSend(ChannelName, notification)
+    }
+
+    fun publishToChannel(channel: String, message: String) {
+        redisTemplate.convertAndSend(channel, message)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/event/redis/subscriber/NotificationSubscriber.kt
+++ b/src/main/kotlin/com/lgcms/notification/event/redis/subscriber/NotificationSubscriber.kt
@@ -1,0 +1,35 @@
+package com.lgcms.notification.event.redis.subscriber
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.lgcms.notification.domain.NotificationEntity
+import com.lgcms.notification.service.NotificationSSEBroadcaster
+import jakarta.annotation.PostConstruct
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationSubscriber(
+    private val redisMessageListenerContainer: RedisMessageListenerContainer,
+    private val sseBroadcaster: NotificationSSEBroadcaster,
+    private val objectMapper: ObjectMapper,
+) : MessageListener {
+
+    private val ChannelName = "notifications_internal"
+
+    @PostConstruct
+    fun subscribeToNotifications() {
+        redisMessageListenerContainer.addMessageListener(this, ChannelTopic(ChannelName))
+    }
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        handleNotification(String(message.body))
+    }
+
+    private fun handleNotification(notification: String) {
+        val notificationData = objectMapper.readValue(notification, NotificationEntity::class.java)
+        sseBroadcaster.broadcast(notificationData.memberId, notificationData)
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/lgcms/notification/repository/NotificationRepository.kt
@@ -13,4 +13,10 @@ interface NotificationRepository : CoroutineCrudRepository<NotificationEntity, U
         ORDER BY n.created_at DESC
         """)
     suspend fun findByMemberId(memberId: Long): List<NotificationEntity>
+    @Query("""
+        SELECT *
+        FROM notifications AS n
+        WHERE n.member_id = :memberId AND n.id = :notificationId
+        """)
+    suspend fun findByMemberIdAndId(memberId: Long, notificationId: UUID): List<NotificationEntity>
 }

--- a/src/main/kotlin/com/lgcms/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/lgcms/notification/repository/NotificationRepository.kt
@@ -1,0 +1,16 @@
+package com.lgcms.notification.repository
+
+import com.lgcms.notification.domain.NotificationEntity
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import java.util.UUID
+
+interface NotificationRepository : CoroutineCrudRepository<NotificationEntity, UUID> {
+    @Query("""
+        SELECT *
+        FROM notifications AS n
+        WHERE n.member_id = :memberId
+        ORDER BY n.created_at DESC
+        """)
+    suspend fun findByMemberId(memberId: Long): List<NotificationEntity>
+}

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationSSEBroadcaster.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationSSEBroadcaster.kt
@@ -1,0 +1,37 @@
+package com.lgcms.notification.service
+
+import com.lgcms.notification.domain.NotificationEntity
+import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.receiveAsFlow
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class NotificationSSEBroadcaster {
+    private val subscribers = ConcurrentHashMap<Long, Channel<NotificationEntity>>()
+
+    suspend fun subscribe(memberId: Long): Flow<NotificationEntity> {
+        val channel = Channel<NotificationEntity>(Channel.Factory.UNLIMITED)
+        subscribers[memberId] = channel
+        return channel.receiveAsFlow()
+            .onCompletion {
+                subscribers.remove(memberId)
+                channel.close()
+            }
+    }
+
+    fun broadcast(memberId: Long, notification: NotificationEntity) {
+        subscribers[memberId]?.trySend(notification)
+    }
+
+    fun getActiveSubscriberCount(): Int = subscribers.size
+
+    @PreDestroy
+    fun cleanup() {
+        subscribers.values.forEach { it.close() }
+        subscribers.clear()
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
@@ -9,6 +9,7 @@ import com.lgcms.notification.domain.NotificationEntity
 import com.lgcms.notification.domain.NotificationEntityFactory
 import com.lgcms.notification.domain.NotificationType
 import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
+import com.lgcms.notification.event.kafka.producer.NotificationProducer
 import com.lgcms.notification.repository.NotificationRepository
 import kotlinx.coroutines.flow.Flow
 import org.springframework.stereotype.Service
@@ -20,6 +21,7 @@ class NotificationService(
     private val notificationEntityFactory: NotificationEntityFactory,
     private val objectMapper: ObjectMapper,
     private val sseBroadcaster: NotificationSSEBroadcaster,
+    private val notificationProducer: NotificationProducer,
 ) {
     suspend fun convertEventAndSave(
         request: KafkaEvent<*>
@@ -61,5 +63,9 @@ class NotificationService(
         val notifications = notificationRepository.findByMemberIdAndId(memberId, request.notificationId)
         if (notifications.isNotEmpty())
             notificationRepository.deleteById(request.notificationId)
+    }
+
+    suspend fun sendNotification(request: KafkaEvent<NotificationEventRequest.QnaCreated>) {
+        notificationProducer.sendNotificationEvent(request)
     }
 }

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
@@ -9,6 +9,7 @@ import com.lgcms.notification.domain.NotificationEntityFactory
 import com.lgcms.notification.domain.NotificationType
 import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
 import com.lgcms.notification.repository.NotificationRepository
+import kotlinx.coroutines.flow.Flow
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,6 +17,7 @@ class NotificationService(
     private val notificationRepository: NotificationRepository,
     private val notificationEntityFactory: NotificationEntityFactory,
     private val objectMapper: ObjectMapper,
+    private val sseBroadcaster: NotificationSSEBroadcaster,
 ) {
     suspend fun convertEventAndSave(
         request: KafkaEvent<*>
@@ -42,5 +44,9 @@ class NotificationService(
             else -> throw BaseException(NotificationError.NO_SUCH_NOTIFICATION_TYPE)
         }
         return notificationRepository.save(notificationEntityFactory.create(notificationRequest))
+    }
+
+    suspend fun subscribe(memberId: Long): Flow<NotificationEntity> {
+        return sseBroadcaster.subscribe(memberId)
     }
 }

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
@@ -68,4 +68,11 @@ class NotificationService(
     suspend fun sendNotification(request: KafkaEvent<NotificationEventRequest.QnaCreated>) {
         notificationProducer.sendNotificationEvent(request)
     }
+
+    fun getServerStatus(): Map<String, Any> {
+        return mapOf(
+            "activeSubscribers" to sseBroadcaster.getActiveSubscriberCount(),
+            "status" to "RUNNING"
+        )
+    }
 }

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
@@ -49,4 +49,8 @@ class NotificationService(
     suspend fun subscribe(memberId: Long): Flow<NotificationEntity> {
         return sseBroadcaster.subscribe(memberId)
     }
+
+    suspend fun findById(memberId: Long): List<NotificationEntity> {
+        return notificationRepository.findByMemberId(memberId)
+    }
 }

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
@@ -1,0 +1,46 @@
+package com.lgcms.notification.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.lgcms.notification.common.dto.exception.BaseException
+import com.lgcms.notification.common.dto.exception.NotificationError
+import com.lgcms.notification.common.kafka.dto.KafkaEvent
+import com.lgcms.notification.domain.NotificationEntity
+import com.lgcms.notification.domain.NotificationEntityFactory
+import com.lgcms.notification.domain.NotificationType
+import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
+import com.lgcms.notification.repository.NotificationRepository
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationService(
+    private val notificationRepository: NotificationRepository,
+    private val notificationEntityFactory: NotificationEntityFactory,
+    private val objectMapper: ObjectMapper,
+) {
+    suspend fun convertEventAndSave(
+        request: KafkaEvent<*>
+    ): NotificationEntity {
+        val notificationRequest = when (request.eventType) {
+            NotificationType.MEMBER_JOINED.toString() ->
+                objectMapper.convertValue(request.data, NotificationEventRequest.MemberJoined::class.java)
+
+            NotificationType.ROLE_MODIFIED.toString() ->
+                objectMapper.convertValue(request.data, NotificationEventRequest.RoleModified::class.java)
+
+            NotificationType.QNA_CREATED.toString() ->
+                objectMapper.convertValue(request.data, NotificationEventRequest.QnaCreated::class.java)
+
+            NotificationType.QNA_ANSWERED.toString() ->
+                objectMapper.convertValue(request.data, NotificationEventRequest.QnaAnswered::class.java)
+
+            NotificationType.ENCODING_STATUS.toString() ->
+                objectMapper.convertValue(request.data, NotificationEventRequest.EncodingStatus::class.java)
+
+            NotificationType.LEVELTEST_REPORT_REQUEST.toString() ->
+                objectMapper.convertValue(request.data, NotificationEventRequest.LevelTestReportRequested::class.java)
+
+            else -> throw BaseException(NotificationError.NO_SUCH_NOTIFICATION_TYPE)
+        }
+        return notificationRepository.save(notificationEntityFactory.create(notificationRequest))
+    }
+}

--- a/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/lgcms/notification/service/NotificationService.kt
@@ -1,6 +1,7 @@
 package com.lgcms.notification.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.lgcms.notification.api.dto.NotificationReadRequest
 import com.lgcms.notification.common.dto.exception.BaseException
 import com.lgcms.notification.common.dto.exception.NotificationError
 import com.lgcms.notification.common.kafka.dto.KafkaEvent
@@ -11,6 +12,7 @@ import com.lgcms.notification.event.kafka.dto.NotificationEventRequest
 import com.lgcms.notification.repository.NotificationRepository
 import kotlinx.coroutines.flow.Flow
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class NotificationService(
@@ -52,5 +54,12 @@ class NotificationService(
 
     suspend fun findById(memberId: Long): List<NotificationEntity> {
         return notificationRepository.findByMemberId(memberId)
+    }
+
+    @Transactional
+    suspend fun readNotification(memberId: Long, request: NotificationReadRequest) {
+        val notifications = notificationRepository.findByMemberIdAndId(memberId, request.notificationId)
+        if (notifications.isNotEmpty())
+            notificationRepository.deleteById(request.notificationId)
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,6 +1,11 @@
+server:
+  port: 38110
+
 spring:
+  application:
+    name: backend-notification
   r2dbc:
-    url: r2dbc:pool:postgresql://localhost:5432/notification
+    url: r2dbc:pool:postgresql://localhost:38121/notification
     username: lgcms
     password: 1234
     properties:
@@ -9,13 +14,37 @@ spring:
       statementTimeout: PT60S
       lockTimeout: PT30S
 
-logging:
-  level:
-    org.springframework.r2dbc: DEBUG
-    io.r2dbc.pool: DEBUG
-    io.r2dbc.postgresql: DEBUG
-    org.springframework.data.r2dbc: DEBUG
-    org.springframework.data.r2dbc.core: DEBUG
+  kafka:
+    bootstrap-servers: localhost:38123
 
-server:
-  port: 38110
+    listener:
+      ack-mode: manual_immediate
+
+    consumer:
+      group-id: ${spring.application.name}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      enable-auto-commit: false
+      auto-offset-reset: latest
+      max-poll-records: 10
+      properties:
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+  data:
+    redis:
+      host: localhost
+      port: 38122
+      database: 5
+
+front-routes:
+  student-main-page: /main
+  lecturer-main-page: /userpage/lecturer
+  qna-page: /qna/%d
+  lecture-edit-page: /lessons/manage/%d
+  leveltest-report-page: /member/student/report/%d

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS notifications;
+
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    notification_type VARCHAR(50) NOT NULL,
+    member_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    web_path VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_id ON notifications(id);
+CREATE INDEX IF NOT EXISTS idx_member_id ON notifications(member_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_type ON notifications(notification_type);
+CREATE INDEX IF NOT EXISTS idx_created_at ON notifications(created_at);

--- a/src/test/kotlin/com/lgcms/notification/NotificationApplicationTests.kt
+++ b/src/test/kotlin/com/lgcms/notification/NotificationApplicationTests.kt
@@ -2,7 +2,9 @@ package com.lgcms.notification
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
+@ActiveProfiles("test")
 @SpringBootTest
 class NotificationApplicationTests {
 


### PR DESCRIPTION
## 작업 내용
    - 카프카 기반 알림 토픽 컨슈머와 Redis pub/sub 기반 SSE 알림 API
    - 알림 읽음 처리 (제거)
    - 알림 기록 목록으로 전체 조회
## 회고, 느낀점 (옵션)
    - 코틀린은 데이터 타입이 신기하네요